### PR TITLE
Fix startup loop by skipping StackchanSystemConfig

### DIFF
--- a/src/communication_config.h
+++ b/src/communication_config.h
@@ -10,7 +10,6 @@
 #include <vector>
 #include <algorithm>
 #include <WiFi.h>
-#include <Stackchan_system_config.h>
 
 #define MAX_WIFI_NETWORKS 10
 
@@ -167,17 +166,6 @@ struct CommunicationConfig {
     return valid;
   }
   
-  void loadFromSystemConfig(StackchanSystemConfig& system_config) {
-    // stackchan-arduinoライブラリからの設定読み込み
-    // 実際の実装では、system_configのAPIに合わせて調整が必要
-    
-    // 基本設定から言語設定を読み込み
-    // language = system_config.getBalloonConfig().font_language;
-    
-    // デフォルト設定でサンプルネットワークを追加
-    addWiFiNetwork("Home-WiFi", "password123", 1);
-    addWiFiNetwork("Office-WiFi", "office456", 2);
-  }
 };
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,6 @@
 #include <M5Unified.h>
 #include <Avatar.h>
 #include <SD.h>
-#include <Stackchan_system_config.h>
 #include "formatString.hpp"
 #include "communication_config.h"
 #include "wifi_manager.h"
@@ -41,8 +40,6 @@ WebServer* server = nullptr;
 // Bluetooth
 BluetoothSerial SerialBT;
 
-// システム設定
-StackchanSystemConfig system_config;
 
 // 表示制御
 uint32_t display_update_interval = 2000;
@@ -540,18 +537,16 @@ void setup() {
   
   // 設定ファイル読み込み
   M5.Display.setCursor(10, 150);
-  M5.Display.print("Step 7: Config load...");
-  system_config.loadConfig(SD, "");
-  comm_config.loadFromSystemConfig(system_config);
+  M5.Display.print("Step 7: Config SKIP");
+  // StackchanSystemConfig is disabled in this simplified build
+  // Configuration uses default CommunicationConfig values
   M5.Display.setCursor(10, 170);
-  M5.Display.print("Step 8: Config OK");
+  M5.Display.print("Step 8: WebServer obj...");
   
   // Webサーバーポート設定
-  M5.Display.setCursor(10, 190);
-  M5.Display.print("Step 9: WebServer obj...");
   server = new WebServer(comm_config.webserver_port);
-  M5.Display.setCursor(10, 210);
-  M5.Display.print("Step 10: WebServer OK");
+  M5.Display.setCursor(10, 190);
+  M5.Display.print("Step 9: WebServer OK");
   
   // Avatar初期化
   avatar.init();


### PR DESCRIPTION
## Summary
- avoid using StackchanSystemConfig because it causes boot loops
- simplify `CommunicationConfig` header

## Testing
- `platformio run -e m5stack-grey` *(fails: Platform Manager could not install espressif32)*

------
https://chatgpt.com/codex/tasks/task_e_687542c8d5dc8333992e4d347a329665