### PR TITLE
Update BLE device name

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ pio run -e m5stack-grey -t uploadfs
 ### 🔵 BLE WebUI（WiFi不要モード）
 
 WiFi環境がない場合やWiFi接続に失敗した場合、自動的にBLEモードで起動します。
+BLEデバイス名は `StackChan-WebUI` です。
 
 #### BLE接続手順
 

--- a/src/ble_webui.h
+++ b/src/ble_webui.h
@@ -20,7 +20,7 @@ extern String generateWebUIHTML();
 // BLE設定（最もシンプルで確実な設定）
 #define BLE_SERVICE_UUID        "12345678-1234-1234-1234-123456789ABC"  // シンプルなカスタムUUID
 #define BLE_CHARACTERISTIC_UUID "87654321-4321-4321-4321-CBA987654321"  // シンプルなカスタムUUID
-#define BLE_DEVICE_NAME         "StackChan"
+#define BLE_DEVICE_NAME         "StackChan-WebUI"
 
 class BLEWebUIHandler {
 public:


### PR DESCRIPTION
## Summary
- rename BLE device to StackChan-WebUI
- document the default BLE name in BLE WebUI section

## Testing
- `pio run -e m5stack-grey` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_6877830301c88333800a12c0320e8129